### PR TITLE
Allow slightly newer dotnet versions

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.100"
+    "version": "3.1.100",
+    "rollForward": "latestMinor"
   }
 }


### PR DESCRIPTION
I cloned the repo and tried running it on Ubuntu and it failed with the following message.
```
A compatible installed .NET Core SDK for global.json version [3.1.100] from [/home/user/code/fsharp/safe-lite-president/global.json] was not found
Install the [3.1.100] .NET Core SDK or update [/home/user/code/fsharp/safe-lite-president/global.json] with an installed .NET Core SDK:
  3.1.401 [/usr/share/dotnet/sdk]
```

This small change allows it to run with my current dotnet version.